### PR TITLE
Replace in GH URLs dominiquesydow with wolberlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ Dynophores
 ==========
 
 [//]: # (Badges)
-[![GitHub Actions Build Status](https://github.com/dominiquesydow/dynophores/workflows/CI/badge.svg)](https://github.com/dominiquesydow/dynophores/actions?query=branch%3Amaster)
-[![codecov](https://codecov.io/gh/dominiquesydow/dynophores/branch/master/graph/badge.svg)](https://codecov.io/gh/dominiquesydow/dynophores/branch/master)
+[![GitHub Actions Build Status](https://github.com/wolberlab/dynophores/workflows/CI/badge.svg)](https://github.com/wolberlab/dynophores/actions?query=branch%3Amaster)
+[![codecov](https://codecov.io/gh/wolberlab/dynophores/branch/master/graph/badge.svg)](https://codecov.io/gh/wolberlab/dynophores/branch/master)
 [![Documentation Status](https://readthedocs.org/projects/dynophores/badge/?version=latest)](https://dynophores.readthedocs.io)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dynophores.svg)](https://anaconda.org/conda-forge/dynophores)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,11 +9,11 @@ Dynophores
 Dynamic pharmacophore modeling of molecular interactions
 
 .. image::
-   https://github.com/dominiquesydow/dynophores/workflows/CI/badge.svg
-   :target: https://github.com/dominiquesydow/dynophores/actions
+   https://github.com/wolberlab/dynophores/workflows/CI/badge.svg
+   :target: https://github.com/wolberlab/dynophores/actions
 .. image::
-   https://codecov.io/gh/dominiquesydow/dynophores/branch/master/graph/badge.svg
-   :target: https://codecov.io/gh/dominiquesydow/dynophores/branch/master
+   https://codecov.io/gh/wolberlab/dynophores/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/wolberlab/dynophores/branch/master
 .. image::
    https://readthedocs.org/projects/dynophores/badge/?version=latest
    :target: https://dynophores.readthedocs.io/en/latest/

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -26,12 +26,12 @@ Install from the conda package
 Install from the latest development snapshot
 --------------------------------------------
 
-Install the latest development snapshot from the `GitHub repository's master branch <https://github.com/dominiquesydow/dynophores>`_.
+Install the latest development snapshot from the `GitHub repository's master branch <https://github.com/wolberlab/dynophores>`_.
 
 
 1. Create a new conda environment called ``dyno``::
 
-    mamba env create -f https://raw.githubusercontent.com/dominiquesydow/dynophores/master/devtools/conda-envs/test_env.yaml -n dyno
+    mamba env create -f https://raw.githubusercontent.com/wolberlab/dynophores/master/devtools/conda-envs/test_env.yaml -n dyno
 
 2. Activate the new conda environment::
 
@@ -39,7 +39,7 @@ Install the latest development snapshot from the `GitHub repository's master bra
 
 3. Install ``dynophores`` package via pip::
 
-    pip install https://github.com/dominiquesydow/dynophores/archive/refs/heads/master.zip
+    pip install https://github.com/wolberlab/dynophores/archive/refs/heads/master.zip
 
 4. Test that your installation works::
 

--- a/dynophores/viz/view3d/interactive.py
+++ b/dynophores/viz/view3d/interactive.py
@@ -228,7 +228,7 @@ def _js_point_buffer(buffer, superfeature_id, opacity):
     """
     Create JavaScript string generating a point buffer from buffer parameters.
     TODO: Visualization contains artifacts:
-    - https://github.com/dominiquesydow/dynophores/issues/27
+    - https://github.com/wolberlab/dynophores/issues/27
     - https://github.com/nglviewer/ngl/issues/868
 
     Parameters


### PR DESCRIPTION
## Description
Replace in GH URLs dominiquesydow with wolberlab.

## Todos
  - [x] Replace in GH URLs dominiquesydow with wolberlab
  - [x] GH Actions
    - [x] Link works? https://github.com/dominiquesydow/dynophores/actions > https://github.com/wolberlab/dynophores/actions
  - [x] CodeCov; not working yet!
    - [x] Link works? https://codecov.io/gh/dominiquesydow/dynophores/branch/master > https://codecov.io/gh/wolberlab/dynophores/branch/master Not yet but maybe CI run on master needed; check after merge; open issue on this so that we do not forget https://github.com/wolberlab/dynophores/issues/48
  - [x] RTD https://dynophores.readthedocs.io/
    - [x] ~Link CodeCov to repo/organization?~ not needed
    - [x] Update RTD settings! Build works! https://dynophores.readthedocs.io/en/update-wolberlab/
  - [x] conda-forge https://github.com/conda-forge/dynophores-feedstock
    - [x] Update recipe https://github.com/conda-forge/dynophores-feedstock/pull/3

## Questions
None.

## Status
- [x] Ready to go