### PR TITLE
Upgrade codecov-action to v2

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -71,7 +71,7 @@ jobs:
         pytest $PYTEST_ARGS dynophores/notebooks/*.ipynb -vvv
 
     - name: CodeCov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         file: ./coverage.xml
         flags: unittests

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -73,7 +73,7 @@ jobs:
     - name: CodeCov
       uses: codecov/codecov-action@v2
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         flags: unittests
         name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
 


### PR DESCRIPTION
## Description
Upgrade codecov-actions to v2 since v1 will expire in 2022: https://github.com/codecov/codecov-action

## Todos
  - [x] Update GHA workflow

## Questions
None.

## Status
- [x] Ready to go