### PR TITLE
Integrate dynophore generation and visualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ docs/examples/data
 
 # Sphinx
 docs/autosummary/
+
+# Dynophore JAR file
+dynophores/generate/*.jar

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -5,6 +5,7 @@ channels:
 dependencies:
     # Base depends
   - python>=3.6
+  - openjdk
   - pip
   - numpy
   - pandas  

--- a/dynophores/api.py
+++ b/dynophores/api.py
@@ -1,3 +1,0 @@
-"""
-Defines easy programmatic access for any entry point.
-"""

--- a/dynophores/api/__init__.py
+++ b/dynophores/api/__init__.py
@@ -1,0 +1,3 @@
+from . import create
+from . import visualize
+from . import demo

--- a/dynophores/api/create.py
+++ b/dynophores/api/create.py
@@ -1,0 +1,96 @@
+"""
+Python API to create (i.e. generate and visualize) dynophore data.
+"""
+
+from pathlib import Path
+import subprocess
+import glob
+
+from ..utils import _download_file
+from ..definitions import DYNOPHORE_JAR_URL, DYNOPHORE_JAR_PATH
+from .visualize import visualize
+
+
+def create(pmz_or_pdb_path, dcd_path, out_path, name, feature_def_path, three_letter_code, chain):
+    """
+    Generate and visualize (Jupyter notebook) dynophore data.
+
+    Parameters
+    ----------
+    pmz_or_pdb_path : str or pathlib.Path
+        PMZ or PDB file.
+    dcd_path : str or pathlib.Path
+        DCD file.
+    out_path : str or pathlib.Path
+        Output folder.
+    name : str
+        Dynophore name.
+    feature_def_path : str
+        Optional: Feature definition file.
+    three_letter_code : str
+        Optional: Three letter code of ligand to be used for binding site definition.
+        In combination with PDB file.
+    chain : str
+        Optional: Chain to be used for binding site definition.
+        In combination with PDB file.
+    """
+
+    # Generate dynophore data
+    generate(pmz_or_pdb_path, dcd_path, out_path, name, feature_def_path, three_letter_code, chain)
+
+    # Visualize dynophore data
+    if pmz_or_pdb_path.suffix == ".pdb":
+        pdb_path = pmz_or_pdb_path
+        dyno_paths = sorted(glob.glob(str(out_path / "dynophore_out_*")), reverse=True)
+        dyno_path = Path(dyno_paths[0])
+        visualize(dyno_path, pdb_path, dcd_path)
+    else:
+        print("To generate viz, provide PDB file.")
+
+
+def generate(
+    pmz_or_pdb_path,
+    dcd_path,
+    out_path,
+    name,
+    feature_def_path=None,
+    three_letter_code=None,
+    chain=None,
+):
+    """
+    Generate dynophore data using the dynophore Java library.
+
+    Parameters
+    ----------
+    pmz_or_pdb_path : str or pathlib.Path
+        PMZ or PDB file.
+    dcd_path : str or pathlib.Path
+        DCD file.
+    out_path : str or pathlib.Path
+        Output folder.
+    name : str
+        Dynophore name.
+    feature_def_path : str
+        Optional: Feature definition file.
+    three_letter_code : str
+        Optional: Three letter code of ligand to be used for binding site definition.
+        In combination with PDB file.
+    chain : str
+        Optional: Chain to be used for binding site definition.
+        In combination with PDB file.
+    """
+
+    _download_file(DYNOPHORE_JAR_URL, DYNOPHORE_JAR_PATH)
+
+    command = (
+        f"java -jar {DYNOPHORE_JAR_PATH} "
+        f"--pmz {pmz_or_pdb_path} "
+        f"--dcd {dcd_path} "
+        f"--out {out_path} "
+        f"--name {name} "
+        f"{'' if feature_def_path is None else f'--feature-def-file {feature_def_path}'} "
+        f"{'' if three_letter_code is None else f'--three-letter-code {three_letter_code}'} "
+        f"{'' if chain is None else f'--chain {chain}'} "
+    )
+    command = command.split()
+    subprocess.run(command)

--- a/dynophores/api/demo.py
+++ b/dynophores/api/demo.py
@@ -1,0 +1,34 @@
+"""
+"""
+
+import json
+from pathlib import Path
+from shutil import copyfile
+import subprocess
+
+
+from .. import _version
+from .utils import _copy_notebook, _update_paths_in_notebook, _open_notebook
+
+PATH_TEST_DATA = Path(__file__).parent / ".." / "tests" / "data"
+
+
+def demo(out_path):
+    """
+    Create and open demo visualization notebook based.
+
+    Parameters
+    ----------
+    out_path : str or pathlib.Path
+        Output folder.
+    """
+
+    new_notebook_path = Path(out_path) / "dynophore_demo.ipynb"
+    _copy_notebook(new_notebook_path)
+    _update_paths_in_notebook(
+        new_notebook_path,
+        (PATH_TEST_DATA / "out").absolute(),
+        (PATH_TEST_DATA / "in/startframe.pdb").absolute(),
+        (PATH_TEST_DATA / "in/trajectory.dcd").absolute(),
+    )
+    _open_notebook(new_notebook_path)

--- a/dynophores/api/utils.py
+++ b/dynophores/api/utils.py
@@ -1,0 +1,116 @@
+"""
+Utility functions used to generate and visualize dynophore data.
+"""
+
+import json
+from pathlib import Path
+from shutil import copyfile
+
+
+from .. import _version
+
+
+def _copy_notebook(new_notebook_path):
+    """
+    Copy template dynophore notebook to user-defined workspace.
+    """
+
+    # Set template notebook
+    template_notebook_path = Path(_version.__file__).parent / "notebooks/dynophore.ipynb"
+
+    # Set user notebook filepath
+    new_notebook_path = Path(new_notebook_path)
+    if new_notebook_path.suffix != ".ipynb":
+        raise RuntimeError(
+            f"Input file path must have suffix `.ipynb`. "
+            f"Your input: `{new_notebook_path.absolute()}`"
+        )
+    if not new_notebook_path.exists():
+        new_notebook_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Copy template notebook to user-defined workspace
+    if template_notebook_path.exists():
+        print("\nCopy dynophore notebook to user workspace...")
+        copyfile(template_notebook_path, new_notebook_path)
+        if new_notebook_path.exists():
+            print(f"Dynophore notebook location: `{new_notebook_path.absolute()}`")
+        else:
+            raise RuntimeError(
+                f"Could not create dynophore notebook at selected location "
+                f"`{new_notebook_path.absolute()}`"
+            )
+    else:
+        raise RuntimeError(
+            f"Could not find dynophore notebook at expected location "
+            f"`{template_notebook_path.absolute()}`."
+        )
+
+
+def _update_paths_in_notebook(notebook_path, dyno_path, pdb_path, dcd_path=None):
+    """
+    Read notebook file as string, replace all search instances (filepaths), and overwrite notebook
+    file with this updated string.
+    """
+
+    notebook_path = Path(notebook_path)
+    if not notebook_path.is_file():
+        raise RuntimeError(f"Input is no file or does not exist: `{notebook_path.absolute()}`")
+
+    dyno_path = Path(dyno_path)
+    if not dyno_path.is_dir():
+        raise RuntimeError(f"Input is no file or file does not exist: `{dyno_path.absolute()}`")
+
+    pdb_path = Path(pdb_path)
+    if not pdb_path.is_file():
+        raise RuntimeError(f"Input is no file or file does not exist: `{pdb_path.absolute()}`")
+
+    if dcd_path is not None:
+        dcd_path = Path(dcd_path)
+        if not dcd_path.is_file():
+            raise RuntimeError(f"Input is no file or file does not exist: `{dcd_path.absolute()}`")
+
+    # Replace template filepaths in notebook with user-defined filepaths
+    print("Update filepaths in notebook to user filepaths...")
+
+    search_replace_tuples = [
+        ("../tests/data/out", str(dyno_path.absolute())),
+        ("../tests/data/in/startframe.pdb", str(pdb_path.absolute())),
+    ]
+
+    if dcd_path is not None:
+        search_replace_tuples.append(("../tests/data/in/trajectory.dcd", str(dcd_path.absolute())))
+    else:
+        search_replace_tuples.append(
+            (
+                json.dumps('dcd_path = Path("../tests/data/in/trajectory.dcd")'),
+                json.dumps("dcd_path = None"),
+            )
+        )
+
+    # Read in the file
+    with open(notebook_path, "r") as f:
+        filedata = f.read()
+
+    # Replace the target string
+    for (search_str, replace_str) in search_replace_tuples:
+        filedata = filedata.replace(search_str, replace_str)
+
+    # Write the file out again
+    with open(notebook_path, "w") as f:
+        f.write(filedata)
+
+
+def _open_notebook(notebook_path):
+    """
+    Print message on how to open notebook with Jupyter Lab.
+    """
+
+    notebook_path = Path(notebook_path)
+
+    print(
+        f"""
+\nFinished! To visualize the dynophore results run your notebook in Jupyter Lab:
+
+    jupyter lab {notebook_path.absolute()}
+    """
+    )

--- a/dynophores/api/visualize.py
+++ b/dynophores/api/visualize.py
@@ -1,0 +1,42 @@
+"""
+Python API to visualize dynophore data in a Jupyter notebook.
+"""
+
+from pathlib import Path
+
+from .utils import _copy_notebook, _update_paths_in_notebook, _open_notebook
+
+PATH_TEST_DATA = Path(__file__).parent / "tests" / "data"
+
+
+def visualize(dyno_path, pdb_path, dcd_path=None):
+    """
+    Visualize dynophore data in a Jupyter notebook,
+
+    Parameters
+    ----------
+    dyno_path : str or pathlib.Path
+        Dynophore output folder.
+    pdb_path : str or pathlib.Path
+        PDB file.
+    dcd_path : str or pathlib.Path
+        Optional: DCD file.
+    """
+
+    new_notebook_path = dyno_path / "dynophore.ipynb"
+
+    if not dyno_path.is_dir():
+        raise RuntimeError(
+            f"Input is no directory or directory does not exist: `{dyno_path.absolute()}`"
+        )
+
+    if not pdb_path.is_file():
+        raise RuntimeError(f"Input is no file or file does not exist: `{pdb_path.absolute()}`")
+
+    if dcd_path is not None:
+        if not dcd_path.is_file():
+            raise RuntimeError(f"Input is no file or file does not exist: `{dcd_path.absolute()}`")
+
+    _copy_notebook(new_notebook_path)
+    _update_paths_in_notebook(new_notebook_path, dyno_path, pdb_path, dcd_path)
+    _open_notebook(new_notebook_path)

--- a/dynophores/definitions.py
+++ b/dynophores/definitions.py
@@ -1,0 +1,9 @@
+"""
+Definitions for dynophore generation and visualization.
+"""
+
+from pathlib import Path
+
+DYNOPHORE_JAR_NAME = "dynophore.jar"
+DYNOPHORE_JAR_URL = f"https://drug-design.de/dynophore/downloads/{DYNOPHORE_JAR_NAME}"
+DYNOPHORE_JAR_PATH = Path(__file__).parent / "generate" / DYNOPHORE_JAR_NAME

--- a/dynophores/utils.py
+++ b/dynophores/utils.py
@@ -2,8 +2,39 @@
 Contains utility functions.
 """
 
+import logging
+from pathlib import Path
+
+import wget
 import numpy as np
 from matplotlib import colors
+
+_logger = logging.getLogger(__name__)
+
+
+def _download_file(target_url, target_path):
+    """
+    Download a file from target URL to be saved as defined in the target path.
+
+    Parameters
+    ----------
+    target_url : str
+        Target URL.
+    target_path : str or pathlib.Path
+        Path to target file.
+    """
+
+    target_path = Path(target_path)
+
+    if target_path.name != Path(target_url).name:
+        raise ValueError("File name in target URL and target path must be the same.")
+
+    if Path(target_path).exists():
+        _logger.warning("Dynophore installer already available. Continue.")
+    else:
+        _logger.warning(f"Download from: {target_url}")
+        _logger.warning(f"Download to: {target_path.parent}")
+        wget.download(target_url, str(target_path.parent))
 
 
 def hex_to_rgb_saturation_sequence(hex, sequence_length, min_saturation=0.2):

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     # Comment out this line to prevent the files from being packaged with your software
     include_package_data=True,
     # Entry point
-    entry_points={"console_scripts": ["dynoviz = dynophores.cli:main"]},
+    entry_points={"console_scripts": ["dynophore = dynophores.cli:main"]},
     # Allows `setup.py test` to work correctly with pytest
     setup_requires=[] + pytest_runner,
     # Additional entries you may want simply uncomment the lines you want and fill in the data


### PR DESCRIPTION
## Description
Enable combined dynophore generation and visualization from CLI.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Restructure CLI entirely (rename CLI command from `dynoviz` to `dynophore`
    - [x] `dynophore create`: Generate and visualize dynophore data (visualization in Jupyter notebook)
    - [x] `dynophore visualize`: Visualize already generated dynophore data (set up notebook)
    - [x] `dynophore demo`: Show demo visualization (set up example notebook)
  - [x] Add heavy lifting to `dynophores.api` module; call functions from there in `dynophores.cli`
  - [x] Do not open notebook automatically; instead, print at the very end the command to the console that the user needs to type to load the notebook
  - [ ] Update CLI instructions in documentation
  - [ ] Update CLI-related tests (use test code from `teachopencadd`)
  - [ ] Check if all functions etc. have docstrings
  - [ ] Be user friendly
    - [ ] Do not overwrite files; check where this could happen
    - [ ] Enable file downloads from any OS (at the moment we are using `wget` (only pip installable, and I think only for Linux; check!)

## Questions
  - [ ] Dynophore output paths have time-stamps; that complicates the generation>visualization; can we maybe loose the time tag?
  - [ ] At the moment the console output is quite a zoo due to the two packages that are run; clean that up!

## Status
- [ ] Ready to go