### PR TITLE
Support Python 3.12 only

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -26,15 +26,11 @@ jobs:
       matrix:
         cfg:
           - os: ubuntu-latest
-            python-version: "3.8"
-          - os: ubuntu-latest
-            python-version: "3.9"
-          - os: ubuntu-latest
-            python-version: "3.10"
+            python-version: "3.12"
           - os: macos-latest
-            python-version: "3.8"
+            python-version: "3.12"
           - os: windows-latest
-            python-version: "3.8"
+            python-version: "3.12"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -111,18 +111,6 @@ jobs:
         run: |
           flake8 --config setup.cfg dynophores
 
-      - name: Run black-nb check
-        shell: bash -l {0}
-        run: |
-          black-nb --check -l 99 docs/tutorials/*.ipynb
-          black-nb --check -l 99 dynophores/notebooks/*.ipynb
-
-      - name: Run flake8-nb
-        shell: bash -l {0}
-        run: |
-          flake8-nb --config setup.cfg docs/tutorials/*.ipynb
-          flake8-nb --config setup.cfg dynophores/notebooks/*.ipynb
-
   docs:
     name: Docs test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -82,7 +82,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: [3.12]
 
     steps:
       - uses: actions/checkout@v3
@@ -129,7 +129,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: [3.12]
 
     steps:
       - uses: actions/checkout@v3

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   # Base depends
-  - python>=3.8
+  - python>=3.12
   - pip
   - numpy
   - pandas

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -32,6 +32,3 @@ dependencies:
   # Developement
   - black
   - flake8
-  - pip:
-      - black-nb
-      - flake8-nb

--- a/dynophores/cli.py
+++ b/dynophores/cli.py
@@ -102,7 +102,7 @@ def _greet():
     with open(logo_path, "r", encoding="ascii") as f:
         print(f.read())
     title_str = f"Dynophores CLI {_version.get_versions()['version']}"
-    print(f"\n{title_str:^64}")
+    print(f"\n{title_str: ^64}")
 
 
 def _create_viz(args):
@@ -114,16 +114,16 @@ def _create_viz(args):
 
     dyno_path = Path(args.dyno)
     if not dyno_path.is_dir():
-        raise RuntimeError(f"Input is no file or file does not exist: `{dyno_path.absolute()}`")
+        raise RuntimeError(f"Input is no file or file does not exist: {dyno_path.absolute()}")
 
     pdb_path = Path(args.pdb)
     if not pdb_path.is_file():
-        raise RuntimeError(f"Input is no file or file does not exist: `{pdb_path.absolute()}`")
+        raise RuntimeError(f"Input is no file or file does not exist: {pdb_path.absolute()}")
 
     if args.dcd is not None:
         dcd_path = Path(args.dcd)
         if not dcd_path.is_file():
-            raise RuntimeError(f"Input is no file or file does not exist: `{dcd_path.absolute()}`")
+            raise RuntimeError(f"Input is no file or file does not exist: {dcd_path.absolute()}")
     else:
         dcd_path = None
 
@@ -168,8 +168,8 @@ def _copy_notebook(new_notebook_path):
     new_notebook_path = Path(new_notebook_path)
     if new_notebook_path.suffix != ".ipynb":
         raise RuntimeError(
-            f"Input file path must have suffix `.ipynb`. "
-            f"Your input: `{new_notebook_path.absolute()}`"
+            f"Input file path must have suffix .ipynb. "
+            f"Your input: {new_notebook_path.absolute()}"
         )
     if not new_notebook_path.exists():
         new_notebook_path.parent.mkdir(parents=True, exist_ok=True)
@@ -179,16 +179,16 @@ def _copy_notebook(new_notebook_path):
         print("\nCopy dynophore notebook to user workspace...")
         copyfile(template_notebook_path, new_notebook_path)
         if new_notebook_path.exists():
-            print(f"Dynophore notebook location: `{new_notebook_path.absolute()}`")
+            print(f"Dynophore notebook location: {new_notebook_path.absolute()}")
         else:
             raise RuntimeError(
                 f"Could not create dynophore notebook at selected location "
-                f"`{new_notebook_path.absolute()}`"
+                f"{new_notebook_path.absolute()}"
             )
     else:
         raise RuntimeError(
             f"Could not find dynophore notebook at expected location "
-            f"`{template_notebook_path.absolute()}`."
+            f"{template_notebook_path.absolute()}."
         )
 
 
@@ -200,20 +200,20 @@ def _update_paths_in_notebook(notebook_path, dyno_path, pdb_path, dcd_path=None)
 
     notebook_path = Path(notebook_path)
     if not notebook_path.is_file():
-        raise RuntimeError(f"Input is no file or does not exist: `{notebook_path.absolute()}`")
+        raise RuntimeError(f"Input is no file or does not exist: {notebook_path.absolute()}")
 
     dyno_path = Path(dyno_path)
     if not dyno_path.is_dir():
-        raise RuntimeError(f"Input is no file or file does not exist: `{dyno_path.absolute()}`")
+        raise RuntimeError(f"Input is no file or file does not exist: {dyno_path.absolute()}")
 
     pdb_path = Path(pdb_path)
     if not pdb_path.is_file():
-        raise RuntimeError(f"Input is no file or file does not exist: `{pdb_path.absolute()}`")
+        raise RuntimeError(f"Input is no file or file does not exist: {pdb_path.absolute()}")
 
     if dcd_path is not None:
         dcd_path = Path(dcd_path)
         if not dcd_path.is_file():
-            raise RuntimeError(f"Input is no file or file does not exist: `{dcd_path.absolute()}`")
+            raise RuntimeError(f"Input is no file or file does not exist: {dcd_path.absolute()}")
 
     # Replace template filepaths in notebook with user-defined filepaths
     print("\nUpdate filepaths in notebook to user filepaths...")
@@ -260,12 +260,12 @@ def _open_notebook(notebook_path):
     notebook_path = Path(notebook_path)
 
     if not notebook_path.exists():
-        raise RuntimeError(f"Input path does not exist: `{notebook_path.absolute()}`")
+        raise RuntimeError(f"Input path does not exist: {notebook_path.absolute()}")
     if not notebook_path.is_file():
-        raise RuntimeError(f"Input path is not a file: `{notebook_path.absolute()}`")
+        raise RuntimeError(f"Input path is not a file: {notebook_path.absolute()}")
     if notebook_path.suffix != ".ipynb":
         raise RuntimeError(
-            f"Input file path must have suffix `.ipynb`. Your input: `{notebook_path.absolute()}`"
+            f"Input file path must have suffix .ipynb. Your input: {notebook_path.absolute()}"
         )
 
     print("Open dynophore notebook with Jupyter Lab...")

--- a/dynophores/core/chemicalfeaturecloud3d.py
+++ b/dynophores/core/chemicalfeaturecloud3d.py
@@ -22,9 +22,11 @@ class ChemicalFeatureCloud3D:
     def __init__(self, center, points, **kwargs):
         self.center = center
         self.points = [
-            point
-            if isinstance(point, ChemicalFeatureCloud3DPoint)
-            else ChemicalFeatureCloud3DPoint(**point)
+            (
+                point
+                if isinstance(point, ChemicalFeatureCloud3DPoint)
+                else ChemicalFeatureCloud3DPoint(**point)
+            )
             for point in points
         ]
 

--- a/dynophores/core/dynophore.py
+++ b/dynophores/core/dynophore.py
@@ -40,9 +40,11 @@ class Dynophore:
         self.id = id
         self.ligand = ligand if isinstance(ligand, Ligand) else Ligand(**ligand)
         self.superfeatures = {
-            superfeature_id: superfeature
-            if isinstance(superfeature, SuperFeature)
-            else SuperFeature(**superfeature)
+            superfeature_id: (
+                superfeature
+                if isinstance(superfeature, SuperFeature)
+                else SuperFeature(**superfeature)
+            )
             for superfeature_id, superfeature in superfeatures.items()
         }
 

--- a/dynophores/core/superfeature.py
+++ b/dynophores/core/superfeature.py
@@ -39,9 +39,9 @@ class SuperFeature:
         self.atom_numbers = atom_numbers
         self.occurrences = occurrences
         self.envpartners = {
-            envpartner_id: envpartner
-            if isinstance(envpartner, EnvPartner)
-            else EnvPartner(**envpartner)
+            envpartner_id: (
+                envpartner if isinstance(envpartner, EnvPartner) else EnvPartner(**envpartner)
+            )
             for envpartner_id, envpartner in envpartners.items()
         }
         self.color = color

--- a/dynophores/tests/core/test_ligand.py
+++ b/dynophores/tests/core/test_ligand.py
@@ -4,7 +4,6 @@ Unit tests for dynophore.core.ligand.Ligand class.
 Uses fixture tests.conftest.envpartner.
 """
 
-
 from pathlib import Path
 
 from dynophores import parsers

--- a/dynophores/viz/plot/static.py
+++ b/dynophores/viz/plot/static.py
@@ -10,7 +10,11 @@ import matplotlib.pyplot as plt
 from matplotlib import ticker
 import seaborn as sns
 
-plt.style.use("seaborn")
+try:
+    plt.style.use("seaborn")
+except OSError:
+    # Needed for matplotlib>=3.8.0
+    plt.style.use("seaborn-v0_8")
 
 
 def superfeatures_vs_envpartners(dynophore, superfeature_ids="all", annotate_heatmap=False):

--- a/dynophores/viz/view2d/static.py
+++ b/dynophores/viz/view2d/static.py
@@ -1,6 +1,7 @@
 """
 Contains RDKit ligand 2D visualizations (static).
 """
+
 from collections import defaultdict
 
 from rdkit import Geometry

--- a/dynophores/viz/view3d/interactive.py
+++ b/dynophores/viz/view3d/interactive.py
@@ -2,6 +2,8 @@
 Contains NGLview 3D visualizations.
 """
 
+# flake8: noqa
+
 import warnings
 
 import numpy as np

--- a/versioneer.py
+++ b/versioneer.py
@@ -339,9 +339,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
## Description
So far, this package ran on Python>=3.8, the CI tested 3.8, 3.9, and 3.10.

Python 3.8 to 3.11 only receives security support anymore, the current latest version is 3.12:
https://devguide.python.org/versions/

Since this package is pretty much standalone to visualize dynophore data, I am aiming to move straight to 3.12.

## Todos
  - [x] Update `setup.py` Python version from >=3.8 to >=3.12
  - [x] Update `versioneer.py` so that it is compatible with Python 3.12
  - [x] Update CI Python version to 3.12 (drop support for 3.8, 3.9, and 3.10)
  - [x] Migrate deprecated matplotlib seaborn style from `seaborn` to `seaborn-v0_8`, fixes https://github.com/wolberlab/dynophores/issues/65
  - [x] Fix `black` and `flake8` issues due to Python update
  - [x] Drop support for `black-nb` and `flake8-nb` to lower maintenance burden of this repo

## Status
- [x] Ready to go